### PR TITLE
feat: Add message delay for Webhook oriented bots such as PluralKit.

### DIFF
--- a/src/main/java/dev/spiritstudios/cantilever/CantileverConfig.java
+++ b/src/main/java/dev/spiritstudios/cantilever/CantileverConfig.java
@@ -30,6 +30,10 @@ public class CantileverConfig extends Config<CantileverConfig> {
 		.comment("Use a %s slot to set the player UUID for your head service of choice!")
 		.build();
 
+	public final Value<Long> discordMessageDelay = value(400L, Codec.LONG)
+		.comment("The delay for sending a message from Discord to Minecraft. Set up to make sure that Webhook related Discord Bots such as PluralKit and Tupperbox may send messages from users.")
+		.build();
+
 	public final Value<String> statusMessage = stringValue("")
 		.build();
 


### PR DESCRIPTION
This PR adds message delay for Webhook oriented bots such as PluralKit and TupperBox.
This makes the ingame message send on Minecraft's IO thread, with a little bit of delay.
The value is configurable but defaults to 400ms because I found that it's a round number that works best.

For reference, 200ms will sometimes have the original message slip through.