### PR TITLE
feat: Add delay for webhook related Discord bots.

### DIFF
--- a/src/main/java/dev/spiritstudios/cantilever/CantileverConfig.java
+++ b/src/main/java/dev/spiritstudios/cantilever/CantileverConfig.java
@@ -30,6 +30,10 @@ public class CantileverConfig extends Config<CantileverConfig> {
 		.comment("Use a %s slot to set the player UUID for your head service of choice!")
 		.build();
 
+	public final Value<Long> discordMessageDelay = value(400L, Codec.LONG)
+		.comment("The delay for sending a message from Discord to Minecraft. Set up to make sure that Webhook related Discord Bots such as PluralKit and Tupperbox may send messages from users.")
+		.build();
+
 	public final Value<String> statusMessage = stringValue("")
 		.build();
 

--- a/src/main/java/dev/spiritstudios/cantilever/CantileverConfig.java
+++ b/src/main/java/dev/spiritstudios/cantilever/CantileverConfig.java
@@ -1,10 +1,13 @@
 package dev.spiritstudios.cantilever;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.spiritstudios.specter.api.config.Config;
 import dev.spiritstudios.specter.api.config.ConfigHolder;
 import dev.spiritstudios.specter.api.config.Value;
 import net.dv8tion.jda.api.entities.Activity;
+
+import java.util.List;
 
 public class CantileverConfig extends Config<CantileverConfig> {
 	public static final ConfigHolder<CantileverConfig, ?> HOLDER = ConfigHolder.builder(Cantilever.id(Cantilever.MODID), CantileverConfig.class)
@@ -30,8 +33,16 @@ public class CantileverConfig extends Config<CantileverConfig> {
 		.comment("Use a %s slot to set the player UUID for your head service of choice!")
 		.build();
 
-	public final Value<Long> discordMessageDelay = value(400L, Codec.LONG)
-		.comment("The delay for sending a message from Discord to Minecraft. Set up to make sure that Webhook related Discord Bots such as PluralKit and Tupperbox may send messages from users.")
+	public final Value<Long> d2mMessageDelay = value(0L, Codec.LONG)
+		.comment("The delay for sending a message from Discord to Minecraft in milliseconds. Set up to make sure that Webhook related Discord Bots such as PluralKit and Tupperbox may send messages from users..")
+		.build();
+
+	public final Value<WebhooksForRemoval> webhooksForRemoval = value(WebhooksForRemoval.DEFAULT, WebhooksForRemoval.CODEC)
+		.comment("Discord Webhooks to attempt to not send any original messages from. 'Original messages' are classified as being posted from a user before a webhook is sent and having matching content within the message. (Will only function when d2mMessageDelay has been set).")
+		.build();
+
+	public final Value<Integer> webhookMessagesToCheck = intValue(3)
+		.comment("The amount of messages after the initial message to search through to find a webhooksForRemoval webhook. (Will only function when d2mMessageDelay has been set).")
 		.build();
 
 	public final Value<String> statusMessage = stringValue("")
@@ -40,4 +51,12 @@ public class CantileverConfig extends Config<CantileverConfig> {
 	public final Value<Activity.ActivityType> activityType = enumValue(Activity.ActivityType.PLAYING, Activity.ActivityType.class)
 		.comment("Options: [playing, streaming, listening, watching, competing]")
 		.build();
+
+	public record WebhooksForRemoval(List<Long> webhookIds, boolean inverted) {
+		public static final WebhooksForRemoval DEFAULT = new WebhooksForRemoval(List.of(), true);
+		public static final Codec<WebhooksForRemoval> CODEC = RecordCodecBuilder.create(inst -> inst.group(
+			Codec.LONG.listOf().fieldOf("webhookIds").forGetter(WebhooksForRemoval::webhookIds),
+			Codec.BOOL.fieldOf("inverted").forGetter(WebhooksForRemoval::inverted)
+		).apply(inst, WebhooksForRemoval::new));
+	}
 }

--- a/src/main/java/dev/spiritstudios/cantilever/bridge/BridgeEvents.java
+++ b/src/main/java/dev/spiritstudios/cantilever/bridge/BridgeEvents.java
@@ -2,14 +2,18 @@ package dev.spiritstudios.cantilever.bridge;
 
 import dev.spiritstudios.cantilever.Cantilever;
 import dev.spiritstudios.cantilever.CantileverConfig;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.message.v1.ServerMessageEvents;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.Util;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public class BridgeEvents {
 	private static Bridge bridge;
@@ -52,6 +56,8 @@ public class BridgeEvents {
 		ServerMessageEvents.CHAT_MESSAGE.register((message, user, params) -> BridgeEvents.bridge.sendWebhookMessageM2D(message, user));
 	}
 
+	private static ScheduledExecutorService scheduler;
+
 	private static void registerDiscordEvents() {
 		BridgeEvents.bridge.api().addEventListener(new ListenerAdapter() {
 			@Override
@@ -61,14 +67,22 @@ public class BridgeEvents {
 					return;
 				}
 
-				Util.getIoWorkerExecutor().execute(() -> {
-					try {
-						// Catch all to make sure that PluralKit, Tupperbox and other webhook utilizing bots'
-						// original message does not get caught and sent.
-						Thread.sleep(CantileverConfig.INSTANCE.discordMessageDelay.get());
+				var webhooksForRemoval = CantileverConfig.INSTANCE.webhooksForRemoval.get();
+				if (scheduler == null && CantileverConfig.INSTANCE.d2mMessageDelay.get() > 0 && (!webhooksForRemoval.webhookIds().isEmpty() || webhooksForRemoval.inverted())) {
+					scheduler = Executors.newScheduledThreadPool(1, runnable -> {
+						var thread = new Thread(runnable, "Cantilever D2M Message Scheduler");
+						thread.setDaemon(true);
+						thread.setUncaughtExceptionHandler((thread1, throwable) -> Cantilever.LOGGER.error("Caught exception in D2M Message Scheduler", throwable));
+						return thread;
+					});
+				}
 
-						var messageHistory = event.getChannel().asTextChannel().getHistoryAround(event.getMessageIdLong(),4).complete();
-						if (messageHistory.getMessageById(event.getMessageIdLong()) == null) {
+				if (scheduler != null) {
+					var historyFuture = event.getChannel().asGuildMessageChannel().getHistoryAfter(event.getMessageIdLong(), CantileverConfig.INSTANCE.webhookMessagesToCheck.get());
+					scheduler.schedule(() -> {
+						var history = historyFuture.complete();
+						if (!history.isEmpty() && !event.isWebhookMessage() && history.getRetrievedHistory().stream()
+							.noneMatch(message -> isMessageWebhook(message, event.getMessage()))) {
 							return;
 						}
 
@@ -78,10 +92,27 @@ public class BridgeEvents {
 							)),
 							true
 						));
-					} catch (InterruptedException e) {
-						throw new RuntimeException(e);
-					}
-				});
+					}, CantileverConfig.INSTANCE.d2mMessageDelay.get(), TimeUnit.MILLISECONDS);
+					return;
+				}
+
+				BridgeEvents.bridge.sendBasicMessageD2M(new BridgeTextContent(
+					Text.of(CantileverConfig.INSTANCE.gameChatFormat.get().formatted(
+						event.getAuthor().getName(), event.getMessage().getContentDisplay()
+					)),
+					true
+				));
+			}
+
+			private static boolean isMessageWebhook(Message message, Message originalMessage) {
+				if (!message.isWebhookMessage() || message.getAuthor().getIdLong() == BridgeEvents.bridge.getWebhookId() ||
+					!originalMessage.getContentRaw().contains(message.getContentRaw())) {
+					return false;
+				}
+
+				var webhooksForRemoval = CantileverConfig.INSTANCE.webhooksForRemoval.get();
+				return webhooksForRemoval.webhookIds().stream()
+					.anyMatch(s -> s == message.getAuthor().getIdLong() ^ webhooksForRemoval.inverted());
 			}
 		});
 	}


### PR DESCRIPTION
Possibly quite overengineered, this should be a catch all case.

Turned off by default (d2mMessageDelay set to 0.)

500ms is the ideal value for PluralKit.

## Why not use the PluralKit API?
I felt it was best to catch all (for example, Tupperbox) rather than exclusively PluralKit, so I instead checked the next 3 messages to check if any of them are a webhook that the originally sent message contains the contents of.

Additionally, this method is a lot faster than calling the PluralKit API, at the benefit/cost of potentially catching non PK webhook messages.
This is why I added some extra fields to the configuration file.