### PR TITLE
build: Modernize build script.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,11 +19,10 @@ group = mod.group
 base.archivesName = mod.id
 
 loom {
-	splitEnvironmentSourceSets()
+	serverOnlyMinecraftJar()
 
 	mods.create(mod.id) {
 		sourceSet(sourceSets.getByName("main"))
-		sourceSet(sourceSets.getByName("client"))
 	}
 }
 
@@ -63,6 +62,8 @@ tasks.processResources {
 
 tasks.shadowJar {
 	tasks.shadowJar.get().configurations.set(arrayListOf(project.configurations.shadow.get()))
+	relocate("net.dv8tion.jda", "dev.spiritstudios.cantilever.jda.shade")
+	relocate("com.eduardomcb.discord.webhook", "dev.spiritstudios.cantilever.discord.webhook.shade")
 }
 
 tasks.remapJar {


### PR DESCRIPTION
- Disable split source-sets.
- Enabled server only Minecraft JAR.
- Relocated shadowed dependencies.