### PR TITLE
fix: Make command based player messages use the player within the context.

### DIFF
--- a/src/main/java/dev/spiritstudios/cantilever/bridge/Bridge.java
+++ b/src/main/java/dev/spiritstudios/cantilever/bridge/Bridge.java
@@ -12,7 +12,6 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.session.ReadyEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.GatewayIntent;
-import net.minecraft.network.message.SignedMessage;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.MutableText;
@@ -122,9 +121,9 @@ public class Bridge {
 		bridgeChannel.sendMessage(message).complete();
 	}
 
-	public void sendWebhookMessageM2D(SignedMessage message, ServerPlayerEntity sender) {
+	public void sendWebhookMessageM2D(Text message, ServerPlayerEntity sender) {
 		if (this.bridgeChannelWebhook == null) {
-			sendBasicMessageM2D(message.getContent().getString());
+			sendBasicMessageM2D(message.getString());
 			LOGGER.error("Webhook does not exist in channel {}. Please make sure to allow your bot to manage webhooks!", bridgeChannel.getId());
 			return;
 		}
@@ -134,7 +133,7 @@ public class Bridge {
 			new WebhookMessageBuilder()
 				.setUsername(username)
 				.setAvatarUrl(CantileverConfig.INSTANCE.webhookFaceApi.get().formatted(sender.getUuidAsString()))
-				.append(filterMessageM2D(message.getContent().getString()))
+				.append(filterMessageM2D(message.getString()))
 				.build()
 		);
 	}

--- a/src/main/java/dev/spiritstudios/cantilever/bridge/BridgeEvents.java
+++ b/src/main/java/dev/spiritstudios/cantilever/bridge/BridgeEvents.java
@@ -53,10 +53,10 @@ public class BridgeEvents {
 
 		ServerMessageEvents.COMMAND_MESSAGE.register((message, source, parameters) -> {
 			if (message.getContent().getContent() instanceof BridgeTextContent content && content.bot()) return;
-			BridgeEvents.bridge.sendBasicMessageM2D(CantileverConfig.INSTANCE.gameEventFormat.get().formatted(message.getContent().getString()));
+			BridgeEvents.bridge.sendWebhookMessageM2D(message.getContent(), source.getPlayer());
 		});
 
-		ServerMessageEvents.CHAT_MESSAGE.register((message, user, params) -> BridgeEvents.bridge.sendWebhookMessageM2D(message, user));
+		ServerMessageEvents.CHAT_MESSAGE.register((message, user, params) -> BridgeEvents.bridge.sendWebhookMessageM2D(message.getContent(), user));
 	}
 
 	private static ScheduledExecutorService scheduler;


### PR DESCRIPTION
###### Apologies for the incorrect commit message. I couldn't find out that it was wrong in time.
Makes command based player messages such as `/say` and `/me` use the player specific webhook flavor.
This is probably not a perfect solution for `/me`, but I think it's at least better than a raw message being sent by the server.

## /say through Discord.
<img width="354" height="84" alt="image" src="https://github.com/user-attachments/assets/11170748-ad23-4192-a091-96b6d92abba9" />

## /say in Minecraft
<img width="317" height="38" alt="image" src="https://github.com/user-attachments/assets/9abfe3ac-3823-432a-9417-05401b985446" />